### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
             {
                 "paths": {
                     "bootstrap-table": "bootstrap-table",
-                    "bootstrap-table-min": "bootstrap-table.min",
+                    "bootstrap-table-min": "bootstrap-table.min"
                 },
                 "shim": {
                     "bootstrap-table": {


### PR DESCRIPTION
remove unnecessary comma(,)

org.webjars.RequireJS.getSetupJavaScript can not output the requirejs config, because of the comma
